### PR TITLE
Update hoops.js

### DIFF
--- a/lib/hoops.js
+++ b/lib/hoops.js
@@ -170,7 +170,7 @@
 
     // Iterate and set undefined keys to an empty object along the path
     for (i = 0; i < length; i++) {
-      if (typeof current[keys[i]] !== 'object') {
+      if (!(current[keys[i]] instanceof Object)) {
         current[keys[i]] = {};
       }
 


### PR DESCRIPTION
setIn fails if the value equals null since typeof null === "object"
